### PR TITLE
FIX: update obsolete torch requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 outputs/
 wandb/
 .history/
+env/
+venv/
+.tree_venv/
+__pycache__

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ source .tree_venv/bin/activate
 pip install -r requirements.txt
 ```
 Technical details:
-* CUDA 11.6
-* torch 1.7.1+cu110
+* CUDA 11.7
+* torch 1.13.1+cu117
 
 **Hugging Face Diffusers Library**  
 Our code relies on the [diffusers](https://github.com/huggingface/diffusers) library and the official [Stable Diffusion v1.4](https://huggingface.co/CompVis/stable-diffusion-v1-4) model.
@@ -57,6 +57,7 @@ All datasets used from Textual Inversion can be found under "datasets".
 The logic for generating the tree is under "main_multiseed.py", which runs the framwork for a <b>single node</b>.
 You can generate the tree by passing your own parameters to main_multiseed.py. An example is given in "run_decompose.sh":
 ```
+export GPU_ID=<your GPU ID, ex. - 0>
 python main_multiseed.py --parent_data_dir "cat_sculpture/" --node v0 --test_name "v0" --GPU_ID "${GPU_ID}" --multiprocess 0
 ```
 Notes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--extra-index-url https://download.pytorch.org/whl/cu117
 absl-py==1.4.0
 accelerate==0.16.0
 aiohttp==3.8.4
@@ -95,9 +96,9 @@ tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.1
 threadpoolctl==3.1.0
 tokenizers==0.13.2
-torch==1.7.1+cu110
-torchaudio==0.7.2
-torchvision==0.8.2+cu110
+torch==1.13.1+cu117
+torchaudio==0.13.1
+torchvision==0.14.1+cu117
 tornado==6.2
 tqdm==4.64.1
 traitlets==5.9.0


### PR DESCRIPTION
This PR fixes #20 where installing requirements show an error `ERROR: No matching distribution found for torch==1.7.1+cu110`.

After updating the requirements, the tree generation now runs correctly:
<img width="563" alt="スクリーンショット 2024-01-02 11 54 24" src="https://github.com/google/inspiration_tree/assets/35907066/5951dc3e-fde8-4339-99ee-7cfc2f7a0a9d">

This has been tested on the following environment:
```
Operating System: Ubuntu 20.04.6 LTS
Kernel: Linux 5.15.0-1042-azure
Architecture: x86-64
NVIDIA-SMI Driver Version: 525.125.06
CUDA Version: 12.0
GPU: NVIDIA A100 80G
```

*Additional minor cleanup changes for `.gitignore` and `README` were also added.